### PR TITLE
Adding 3D correction (stall delay model) 

### DIFF
--- a/pybemt/rotor.py
+++ b/pybemt/rotor.py
@@ -152,8 +152,42 @@ class Section:
             
         self.F = F
         return F
- 
-                    
+    
+    def stall_delay_model(self, phi, alpha, Cl, Cd):
+        """
+        The 3D correction model based on Chaviaropoulos and Hansen ref:
+        
+        .. bib::
+            @article{chaviaropoulos2000investigating,
+                     title={Investigating three-dimensional and rotational effects on wind turbine blades by means of a quasi-3D Navier-Stokes solver},
+                     author={Chaviaropoulos, PK and Hansen, Martin OL},
+                     journal={J. Fluids Eng.},
+                     volume={122},
+                     number={2},
+                     pages={330--336},
+                     year={2000}
+                     }
+
+        .. math::
+            Cl_3D = Cl_2D + a (c / r)^h \cos^n{twist} (Cl_inv - Cl_2d) \\
+            Cl_inv = \sqrt{Cl_2d^2 + Cd^2}
+        where:
+        a = 2.2, h = 1.3 and n = 4
+
+        :param float phi: Inflow angle
+        :return: Lift coefficient with 3D correction
+        :rtype: float
+        """
+        Cl_inv = sqrt(Cl**2+Cd**2)
+        twist = alpha - self.pitch
+        r = self.radius - self.rotor.radius_hub
+        c = self.chord
+        
+        a = 2.2
+        h = 1.3
+        n = 4
+        return Cl + a * (c / r) ** h * (cos(twist)) ** n * (Cl_inv - Cl)
+                
     def airfoil_forces(self, phi):
         """
         Force coefficients on an airfoil, decomposed in axial and tangential directions:


### PR DESCRIPTION
The classical BEMT is not designed to account for flow three-dimensionality as no interaction between each blade section to the neighboring sections is assumed in the model. Thus, the approach depends strongly on the supplied aerodynamic polars. Due to this limitation, the 3D effects shall be stimulated in the given polars. In the present works, the 3D correction model based on Chaviaropoulos and Hansen is used. The model was developed by adopting the idea from Snel to express the 3-D correction of the lift coefficient C_L as a fraction of the difference (∆CL) between the inviscid (C_(l,inv)) and the corresponding 2-D value (C_(L,2D)). In this model, the influence of twist angle is introduced in the ∆CL multiplier. The model can be formulated as follows: 
.. math::
Cl_3D = Cl_2D + a (c / r)^h \cos^n{twist} (Cl_inv - Cl_2d) \\
        Cl_inv = \sqrt{Cl_2d^2 + Cd^2}
        where:
        a = 2.2, h = 1.3 and n = 4
        :param float phi: Inflow angle
        :return: Lift coefficient with 3D correction
        :rtype: float
.. bib::
@article{chaviaropoulos2000investigating,
                     title={Investigating three-dimensional and rotational effects on wind turbine blades by means of a quasi-3D 
                     Navier-Stokes solver},
                     author={Chaviaropoulos, PK and Hansen, Martin OL},
                     journal={J. Fluids Eng.},
                     volume={122},
                     number={2},
                     pages={330--336},
                     year={2000}
                     }
the two figures shows the power and thrust coefficients compared to the experimental results for the case of APC 10x7 propeller. The first without 3D correction, and the second with a 3D correction. We can see the small changes in error at J = 0.7
![image](https://user-images.githubusercontent.com/83415766/174401562-9e55f4ed-84db-43c4-a184-c5e7316d1b31.png)
![image](https://user-images.githubusercontent.com/83415766/174401824-8a25debc-2eac-4368-8085-a3de88fa19e8.png)

